### PR TITLE
:bug: fix: Feign Client에서 PATCH 메서드 지원을 위한 Apache HttpClient 5 추가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(./gradlew:*)"
-    ],
-    "deny": [],
-    "ask": []
-  }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'io.github.openfeign:feign-hc5'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/hello/pet/announcementservice/config/FeignConfig.java
+++ b/src/main/java/hello/pet/announcementservice/config/FeignConfig.java
@@ -1,0 +1,14 @@
+package hello.pet.announcementservice.config;
+
+import feign.Logger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+}

--- a/src/main/java/hello/pet/announcementservice/facade/PetServiceFacade.java
+++ b/src/main/java/hello/pet/announcementservice/facade/PetServiceFacade.java
@@ -1,5 +1,6 @@
 package hello.pet.announcementservice.facade;
 
+import feign.FeignException;
 import hello.pet.announcementservice.dto.response.PetResponse;
 import hello.pet.announcementservice.client.PetServiceClient;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,12 @@ public class PetServiceFacade {
     }
 
     public void markAsAnnounced(Long petId) {
-        petServiceClient.markAsAnnounced(petId);
+        try {
+            petServiceClient.markAsAnnounced(petId);
+        } catch (FeignException.Conflict e) {
+            throw new IllegalStateException("해당 펫은 이미 다른 공고에 등록되어 있습니다.");
+        } catch (FeignException e) {
+            throw new IllegalStateException("펫 상태 업데이트 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/hello/pet/announcementservice/facade/UserServiceFacade.java
+++ b/src/main/java/hello/pet/announcementservice/facade/UserServiceFacade.java
@@ -13,8 +13,12 @@ public class UserServiceFacade {
     private final UserServiceClient userServiceClient;
 
     public Optional<String> getNickname(Long userId) {
-        UserDetailResponse userDetail = userServiceClient.getUserDetail(userId);
-        return Optional.ofNullable(userDetail)
-                       .map(UserDetailResponse::getNickname);
+        try {
+            UserDetailResponse userDetail = userServiceClient.getUserDetail(userId);
+            return Optional.ofNullable(userDetail)
+                           .map(UserDetailResponse::getNickname);
+        } catch (Exception e) {
+            return Optional.empty();
+        }
     }
 }

--- a/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
+++ b/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
@@ -135,11 +135,7 @@ public class AnnouncementService {
     }
 
     private void updatePetAsAnnounced(Long petId) {
-        try {
-            petServiceFacade.markAsAnnounced(petId);
-        } catch (Exception e) {
-            throw new IllegalStateException("Pet 상태 업데이트 실패", e);
-        }
+        petServiceFacade.markAsAnnounced(petId);
     }
 
     private void validateOwnership(Announcement announcement, Long shelterId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,18 @@ spring:
 
 server:
   port: 8084
+
+feign:
+  httpclient:
+    hc5:
+      enabled: true
+  client:
+    config:
+      default:
+        loggerLevel: FULL
+
+logging:
+  level:
+    feign: DEBUG
+    hello.pet.announcementservice.client: DEBUG
+    hello.pet.announcementservice.facade: DEBUG


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
다른 서비스 API 호출할 때 HTTP PATCH 메서드 미지원으로 인한 오류를 해결했습니다.

## 🔗 관련 이슈
Closes #18 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [x] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
