### PR TITLE
:sparkles: 공고 삭제 시 펫의 announced 상태를 false로 변경

### DIFF
--- a/src/main/java/hello/pet/announcementservice/client/PetServiceClient.java
+++ b/src/main/java/hello/pet/announcementservice/client/PetServiceClient.java
@@ -17,4 +17,7 @@ public interface PetServiceClient {
 
     @PatchMapping("/{petId}/mark-announced")
     void markAsAnnounced(@PathVariable("petId") Long petId);
+
+    @PatchMapping("/{petId}/unmark-announced")
+    void markAsUnannounced(@PathVariable("petId") Long petId);
 }

--- a/src/main/java/hello/pet/announcementservice/facade/PetServiceFacade.java
+++ b/src/main/java/hello/pet/announcementservice/facade/PetServiceFacade.java
@@ -25,4 +25,12 @@ public class PetServiceFacade {
             throw new IllegalStateException("펫 상태 업데이트 중 오류가 발생했습니다: " + e.getMessage(), e);
         }
     }
+
+    public void markAsUnannounced(Long petId) {
+        try {
+            petServiceClient.markAsUnannounced(petId);
+        } catch (FeignException e) {
+            throw new IllegalStateException("펫 상태 업데이트 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
+    }
 }

--- a/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
+++ b/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
@@ -99,6 +99,9 @@ public class AnnouncementService {
     public void deleteAnnouncement(Long announcementId, Long shelterId) {
         Announcement announcement = findById(announcementId);
         validateOwnership(announcement, shelterId);
+
+        petServiceFacade.markAsUnannounced(announcement.getPetId());
+
         announcementRepository.delete(announcement);
     }
 


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
해당 펫이 등록된 공고를 삭제하면 펫의 announced를 false로 변경하는 OpenFeign 통신을 추가했습니다.

## 🔗 관련 이슈
Closes #20 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [x] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
