### PR TITLE
:sparkles: feat: Spring Scheduler를 활용한 공고 자동 마감 처리 기능 추가

### DIFF
--- a/src/main/java/hello/pet/announcementservice/AnnouncementServiceApplication.java
+++ b/src/main/java/hello/pet/announcementservice/AnnouncementServiceApplication.java
@@ -3,8 +3,10 @@ package hello.pet.announcementservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableFeignClients
+@EnableScheduling
 @SpringBootApplication
 public class AnnouncementServiceApplication {
 

--- a/src/main/java/hello/pet/announcementservice/client/ApplicationServiceClient.java
+++ b/src/main/java/hello/pet/announcementservice/client/ApplicationServiceClient.java
@@ -2,6 +2,8 @@ package hello.pet.announcementservice.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(
@@ -15,4 +17,11 @@ public interface ApplicationServiceClient {
             @RequestParam("announcementId") Long announcementId,
             @RequestParam("userId") Long userId
     );
+
+    /**
+     * 공고 마감 시 해당 공고의 모든 신청 상태를 UNDER_REVIEW로 변경
+     * @param announcementId 마감된 공고 ID
+     */
+    @PutMapping("/announcement/{announcementId}/close")
+    void updateApplicationsToUnderReviewForClosedAnnouncement(@PathVariable("announcementId") Long announcementId);
 }

--- a/src/main/java/hello/pet/announcementservice/controller/SchedulerTestController.java
+++ b/src/main/java/hello/pet/announcementservice/controller/SchedulerTestController.java
@@ -1,0 +1,66 @@
+package hello.pet.announcementservice.controller;
+
+import hello.pet.announcementservice.scheduler.AnnouncementScheduler;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 스케줄러를 수동으로 실행하기 위한 테스트 컨트롤러
+ * <p>
+ * ⚠️ 주의: 개발/테스트 환경 전용 - 운영 환경에서 절대 활성화 금지
+ * <p>
+ * 활성화 방법:
+ * IntelliJ: Run Configuration > Environment variables에 추가 > ENABLE_SCHEDULER_TEST=true
+ */
+@Slf4j
+@RestController
+@RequestMapping("/v1/admin/scheduler")
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "ENABLE_SCHEDULER_TEST",
+        havingValue = "true",
+        matchIfMissing = false  // 기본값 false (안전을 위해 명시)
+)
+public class SchedulerTestController {
+
+    private final AnnouncementScheduler announcementScheduler;
+
+    @PostMapping("/trigger/close-announcements")
+    public ResponseEntity<Map<String, Object>> triggerCloseAnnouncements() {
+        log.info("=== [수동 실행] 공고 마감 스케줄러 시작 ===");
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("startTime", LocalDateTime.now());
+
+        try {
+            // 스케줄러 실행
+            announcementScheduler.closeExpiredAnnouncements();
+
+            response.put("status", "SUCCESS");
+            response.put("message", "공고 마감 스케줄러가 성공적으로 실행되었습니다.");
+            response.put("endTime", LocalDateTime.now());
+
+            log.info("=== [수동 실행] 공고 마감 스케줄러 완료 ===");
+
+        } catch (Exception e) {
+            response.put("status", "FAILURE");
+            response.put("message", "스케줄러 실행 중 오류 발생: " + e.getMessage());
+            response.put("error", e.getClass().getSimpleName());
+            response.put("endTime", LocalDateTime.now());
+
+            log.error("=== [수동 실행] 공고 마감 스케줄러 실행 실패 ===", e);
+
+            return ResponseEntity.internalServerError().body(response);
+        }
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/hello/pet/announcementservice/dto/request/AnnouncementCreateRequest.java
+++ b/src/main/java/hello/pet/announcementservice/dto/request/AnnouncementCreateRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import hello.pet.announcementservice.entity.Announcement;
 import hello.pet.announcementservice.entity.AnnouncementStatus;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +18,8 @@ public class AnnouncementCreateRequest {
     @NotNull
     private Long petId;
 
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    private LocalDateTime endDate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
 
     public Announcement toEntity(Long shelterId) {
         return Announcement.builder()

--- a/src/main/java/hello/pet/announcementservice/dto/request/AnnouncementUpdateRequest.java
+++ b/src/main/java/hello/pet/announcementservice/dto/request/AnnouncementUpdateRequest.java
@@ -2,7 +2,7 @@ package hello.pet.announcementservice.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import hello.pet.announcementservice.entity.AnnouncementStatus;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AnnouncementUpdateRequest {
 
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    private LocalDateTime endDate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
 
     private AnnouncementStatus status;
 }

--- a/src/main/java/hello/pet/announcementservice/dto/response/AnnouncementDetailResponse.java
+++ b/src/main/java/hello/pet/announcementservice/dto/response/AnnouncementDetailResponse.java
@@ -2,6 +2,7 @@ package hello.pet.announcementservice.dto.response;
 
 import hello.pet.announcementservice.entity.Announcement;
 import hello.pet.announcementservice.entity.AnnouncementStatus;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,7 +27,7 @@ public class AnnouncementDetailResponse {
     private Long shelterId;
     private String shelterName;
     private LocalDateTime createdAt;
-    private LocalDateTime endDate;
+    private LocalDate endDate;
     private String imageUrl;
     private AnnouncementStatus announcementStatus;
     private String animalType;

--- a/src/main/java/hello/pet/announcementservice/dto/response/AnnouncementListResponse.java
+++ b/src/main/java/hello/pet/announcementservice/dto/response/AnnouncementListResponse.java
@@ -2,6 +2,7 @@ package hello.pet.announcementservice.dto.response;
 
 import hello.pet.announcementservice.entity.Announcement;
 import hello.pet.announcementservice.entity.AnnouncementStatus;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +20,7 @@ public class AnnouncementListResponse {
     private String personality;
     private int age;
     private Long shelterId;
-    private LocalDateTime endDate;
+    private LocalDate endDate;
     private AnnouncementStatus announcementStatus;
     private String animalType;
 

--- a/src/main/java/hello/pet/announcementservice/entity/Announcement.java
+++ b/src/main/java/hello/pet/announcementservice/entity/Announcement.java
@@ -8,7 +8,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,7 +38,9 @@ public class Announcement {
     @Enumerated(EnumType.STRING)
     private AnnouncementStatus status;
 
-    private LocalDateTime endDate;
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
@@ -50,9 +54,17 @@ public class Announcement {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void updateEndDate(LocalDateTime newEndDate) {
+    public void updateEndDate(LocalDate newEndDate) {
         this.endDate = newEndDate;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    // 마감 여부 확인 메서드 추가
+    public boolean isExpired() {
+        if (this.endDate == null) {
+            return false;
+        }
+        return LocalDate.now(ZoneId.of("Asia/Seoul")).isAfter(this.endDate);
     }
 
     public void softDelete() {

--- a/src/main/java/hello/pet/announcementservice/facade/ApplicationServiceFacade.java
+++ b/src/main/java/hello/pet/announcementservice/facade/ApplicationServiceFacade.java
@@ -13,4 +13,8 @@ public class ApplicationServiceFacade {
     public boolean hasUserAppliedToAnnouncement(Long announcementId, Long userId) {
         return applicationServiceClient.hasUserAppliedToAnnouncement(announcementId, userId);
     }
+
+    public void updateApplicationsToUnderReviewForClosedAnnouncement(Long announcementId) {
+        applicationServiceClient.updateApplicationsToUnderReviewForClosedAnnouncement(announcementId);
+    }
 }

--- a/src/main/java/hello/pet/announcementservice/repository/AnnouncementRepository.java
+++ b/src/main/java/hello/pet/announcementservice/repository/AnnouncementRepository.java
@@ -2,10 +2,14 @@ package hello.pet.announcementservice.repository;
 
 import hello.pet.announcementservice.entity.Announcement;
 import hello.pet.announcementservice.entity.AnnouncementStatus;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +19,14 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
     Page<Announcement> findAllByStatusNot(AnnouncementStatus status, Pageable pageable);
 
     Page<Announcement> findAllByStatus(AnnouncementStatus status, Pageable pageable);
+
+    // 특정 날짜가 마감일인 공고 조회 (스케줄러에서 어제 날짜로 조회하여 오늘 마감 처리)
+    @Query("SELECT a FROM Announcement a WHERE a.endDate = :date AND a.status = :status")
+    List<Announcement> findByEndDateAndStatus(@Param("date") LocalDate date,
+                                              @Param("status") AnnouncementStatus status);
+
+    // 마감일이 특정 날짜 이전인 미처리 공고 조회 (서버 장애 등으로 마감 처리를 놓친 공고 처리용)
+    @Query("SELECT a FROM Announcement a WHERE a.endDate < :date AND a.status = :status")
+    List<Announcement> findExpiredAnnouncements(@Param("date") LocalDate date,
+                                                @Param("status") AnnouncementStatus status);
 }

--- a/src/main/java/hello/pet/announcementservice/scheduler/AnnouncementScheduler.java
+++ b/src/main/java/hello/pet/announcementservice/scheduler/AnnouncementScheduler.java
@@ -1,0 +1,88 @@
+package hello.pet.announcementservice.scheduler;
+
+import hello.pet.announcementservice.entity.Announcement;
+import hello.pet.announcementservice.entity.AnnouncementStatus;
+import hello.pet.announcementservice.repository.AnnouncementRepository;
+import hello.pet.announcementservice.service.AnnouncementService;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AnnouncementScheduler {
+
+    private final AnnouncementRepository announcementRepository;
+    private final AnnouncementService announcementService;
+
+    /**
+     * 매일 자정에 실행되어 마감일이 지난 공고들을 자동으로 마감 처리
+     * cron = "0 0 0 * * *" : 초 분 시 일 월 요일
+     * zone = "Asia/Seoul" : 한국 시간 기준
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void closeExpiredAnnouncements() {
+        log.info("=== 공고 자동 마감 스케줄러 시작 ===");
+
+        try {
+            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+            // 1. 오늘 마감되는 공고들 조회 (endDate가 어제인 공고들)
+            // 예: 1월 15일이 endDate면, 1월 16일 00:00에 마감 처리
+            LocalDate yesterday = today.minusDays(1);
+            List<Announcement> todayClosingAnnouncements =
+                    announcementRepository.findByEndDateAndStatus(yesterday, AnnouncementStatus.OPEN);
+
+            if (!todayClosingAnnouncements.isEmpty()) {
+                log.info("오늘 마감 처리할 공고 수: {}", todayClosingAnnouncements.size());
+                for (Announcement announcement : todayClosingAnnouncements) {
+                    processAnnouncementClosure(announcement);
+                }
+            }
+
+            // 2. 이미 마감일이 지난 공고들도 처리 (서버 다운타임 등으로 놓친 경우 대비)
+            List<Announcement> expiredAnnouncements =
+                    announcementRepository.findExpiredAnnouncements(yesterday, AnnouncementStatus.OPEN);
+
+            if (!expiredAnnouncements.isEmpty()) {
+                log.warn("마감일이 지났지만 처리되지 않은 공고 수: {}", expiredAnnouncements.size());
+                for (Announcement announcement : expiredAnnouncements) {
+                    processAnnouncementClosure(announcement);
+                }
+            }
+
+            log.info("=== 공고 자동 마감 스케줄러 완료 ===");
+
+        } catch (Exception e) {
+            log.error("공고 자동 마감 처리 중 오류 발생", e);
+        }
+    }
+
+    /**
+     * 개별 공고 마감 처리
+     */
+    private void processAnnouncementClosure(Announcement announcement) {
+        try {
+            log.info("공고 ID {} 마감 처리 시작", announcement.getId());
+
+            // 공고 상태를 CLOSED로 변경
+            announcement.changeStatus(AnnouncementStatus.CLOSED);
+            announcementRepository.save(announcement);
+
+            // OpenFeign을 통해 application-service 호출
+            announcementService.updateApplicationStatusToUnderReview(announcement.getId());
+
+            log.info("공고 ID {} 마감 처리 완료", announcement.getId());
+
+        } catch (Exception e) {
+            log.error("공고 ID {} 마감 처리 중 오류 발생", announcement.getId(), e);
+        }
+    }
+}

--- a/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
+++ b/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
@@ -17,12 +17,16 @@ import hello.pet.announcementservice.facade.ApplicationServiceFacade;
 import hello.pet.announcementservice.facade.PetServiceFacade;
 import hello.pet.announcementservice.facade.UserServiceFacade;
 import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -142,12 +146,13 @@ public class AnnouncementService {
         }
     }
 
-    private void validateEndDate(LocalDateTime endDate) {
+    private void validateEndDate(LocalDate endDate) {
         if (endDate == null) {
             throw new IllegalArgumentException("공고 종료일은 필수입니다.");
         }
-        if (endDate.isBefore(LocalDateTime.now())) {
-            throw new IllegalArgumentException("공고 종료일은 현재 시간 이후여야 합니다.");
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        if (endDate.isBefore(today)) {
+            throw new IllegalArgumentException("공고 종료일은 오늘 이후 날짜여야 합니다.");
         }
     }
 
@@ -174,5 +179,20 @@ public class AnnouncementService {
             announcement.changeStatus(request.getStatus());
         }
         announcement.updateTimestamp();
+    }
+
+    /**
+     * 공고 마감 시 해당 공고의 신청들을 UNDER_REVIEW 상태로 변경
+     * 스케줄러에서 호출됨
+     */
+    public void updateApplicationStatusToUnderReview(Long announcementId) {
+        try {
+            log.info("공고 ID {}의 신청 상태 업데이트 시작", announcementId);
+            applicationServiceFacade.updateApplicationsToUnderReviewForClosedAnnouncement(announcementId);
+            log.info("공고 ID {}의 신청 상태 업데이트 완료", announcementId);
+        } catch (Exception e) {
+            log.error("공고 ID {}의 신청 상태 업데이트 중 오류 발생", announcementId, e);
+            // 실패해도 공고 마감 처리는 계속 진행
+        }
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
Spring Scheduler를 활용해 특정 시간이 되면 공고와 신청서의 상태를 변경하는 기능을 구현했습니다.

## 🔗 관련 이슈
Closes #30 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [x] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
