### PR TITLE
:sparkles: feat: 보호소별 공고 조회 API 추가

### DIFF
--- a/src/main/java/hello/pet/announcementservice/controller/AnnouncementController.java
+++ b/src/main/java/hello/pet/announcementservice/controller/AnnouncementController.java
@@ -43,6 +43,13 @@ public class AnnouncementController {
         return ResponseEntity.ok(announcementService.getAllAnnouncements(request));
     }
 
+    @GetMapping("/my")
+    public ResponseEntity<AnnouncementPageResponse> getMyAnnouncements(
+            @ModelAttribute AnnouncementSearchRequest request,
+            @RequestHeader("X-User-Id") Long shelterId) {
+        return ResponseEntity.ok(announcementService.getMyAnnouncements(request, shelterId));
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<AnnouncementDetailResponse> getAnnouncementDetail(
             @PathVariable Long id,

--- a/src/main/java/hello/pet/announcementservice/repository/AnnouncementRepository.java
+++ b/src/main/java/hello/pet/announcementservice/repository/AnnouncementRepository.java
@@ -20,6 +20,8 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
 
     Page<Announcement> findAllByStatus(AnnouncementStatus status, Pageable pageable);
 
+    Page<Announcement> findAllByShelterId(Long shelterId, Pageable pageable);
+
     // 특정 날짜가 마감일인 공고 조회 (스케줄러에서 어제 날짜로 조회하여 오늘 마감 처리)
     @Query("SELECT a FROM Announcement a WHERE a.endDate = :date AND a.status = :status")
     List<Announcement> findByEndDateAndStatus(@Param("date") LocalDate date,

--- a/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
+++ b/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
@@ -12,13 +12,12 @@ import hello.pet.announcementservice.dto.response.PetResponse;
 import hello.pet.announcementservice.entity.Announcement;
 import hello.pet.announcementservice.entity.AnnouncementStatus;
 import hello.pet.announcementservice.exception.UnauthorizedOperationException;
-import hello.pet.announcementservice.repository.AnnouncementRepository;
 import hello.pet.announcementservice.facade.ApplicationServiceFacade;
 import hello.pet.announcementservice.facade.PetServiceFacade;
 import hello.pet.announcementservice.facade.UserServiceFacade;
+import hello.pet.announcementservice.repository.AnnouncementRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +64,22 @@ public class AnnouncementService {
                     request.toPageable()
             );
         }
+
+        Page<AnnouncementListResponse> responses = announcements.map(announcement -> {
+            PetResponse pet = petServiceFacade.getPet(announcement.getPetId());
+            return AnnouncementListResponse.from(announcement, pet);
+        });
+
+        return AnnouncementPageResponse.from(responses, request);
+    }
+
+    @Transactional(readOnly = true)
+    public AnnouncementPageResponse getMyAnnouncements(AnnouncementSearchRequest request, Long shelterId) {
+
+        Page<Announcement> announcements = announcementRepository.findAllByShelterId(
+                shelterId,
+                request.toPageable()
+        );
 
         Page<AnnouncementListResponse> responses = announcements.map(announcement -> {
             PetResponse pet = petServiceFacade.getPet(announcement.getPetId());


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
보호소 자신이 생성한 공고 전체를 조회하는 API 구현했습니다.

## 🔗 관련 이슈
Closes #32 

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [x] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
