### PR TITLE
:sparkles: feat: 공고 목록 조회 시 보호소 닉네임 반환 추가

### DIFF
--- a/src/main/java/hello/pet/announcementservice/dto/response/AnnouncementListResponse.java
+++ b/src/main/java/hello/pet/announcementservice/dto/response/AnnouncementListResponse.java
@@ -20,11 +20,12 @@ public class AnnouncementListResponse {
     private String personality;
     private int age;
     private Long shelterId;
+    private String shelterNickname;
     private LocalDate endDate;
     private AnnouncementStatus announcementStatus;
     private String animalType;
 
-    public static AnnouncementListResponse from(Announcement announcement, PetResponse pet) {
+    public static AnnouncementListResponse from(Announcement announcement, PetResponse pet, String shelterNickname) {
         return AnnouncementListResponse.builder()
                                        .id(announcement.getId())
                                        .breed(pet.getBreed())
@@ -36,6 +37,7 @@ public class AnnouncementListResponse {
                                        .personality(pet.getPersonality())
                                        .age(pet.getAge())
                                        .shelterId(announcement.getShelterId())
+                                       .shelterNickname(shelterNickname)
                                        .endDate(announcement.getEndDate())
                                        .announcementStatus(announcement.getStatus())
                                        .animalType(pet.getAnimalType())

--- a/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
+++ b/src/main/java/hello/pet/announcementservice/service/AnnouncementService.java
@@ -67,7 +67,8 @@ public class AnnouncementService {
 
         Page<AnnouncementListResponse> responses = announcements.map(announcement -> {
             PetResponse pet = petServiceFacade.getPet(announcement.getPetId());
-            return AnnouncementListResponse.from(announcement, pet);
+            String shelterNickname = userServiceFacade.getNickname(announcement.getShelterId()).orElse("닉네임 없음");
+            return AnnouncementListResponse.from(announcement, pet, shelterNickname);
         });
 
         return AnnouncementPageResponse.from(responses, request);
@@ -81,9 +82,11 @@ public class AnnouncementService {
                 request.toPageable()
         );
 
+        String shelterNickname = userServiceFacade.getNickname(shelterId).orElse("닉네임 없음");
+
         Page<AnnouncementListResponse> responses = announcements.map(announcement -> {
             PetResponse pet = petServiceFacade.getPet(announcement.getPetId());
-            return AnnouncementListResponse.from(announcement, pet);
+            return AnnouncementListResponse.from(announcement, pet, shelterNickname);
         });
 
         return AnnouncementPageResponse.from(responses, request);


### PR DESCRIPTION
## 📌 작업 내용
<!-- 이번 PR에서 수정/추가된 핵심 내용을 간단히 작성하세요 -->
공고 조회 API의 반환값에 보호소 닉네임을 추가해 프론트에서 활용할 수 있도록 했습니다.

## 🔗 관련 이슈
Closes #

## ✅ PR 생성 전 체크리스트
- [x] 병합할 브랜치 확인
- [x] 코드 정상 동작 확인

## 💬 리뷰 메모
<!-- 리뷰어에게 강조하거나 논의할 부분을 작성하세요-->
